### PR TITLE
Allow specifying API path instead of hostname

### DIFF
--- a/src/timetagger.ts
+++ b/src/timetagger.ts
@@ -10,7 +10,16 @@ export namespace timetagger {
 		getTitle : Function
 
 		constructor(host: string ,token : string, getTitle : Function){
-			this.serverHost=host+"/timetagger/api/v2";
+			if(host.indexOf("/api")>0){
+				// host is API endpoint
+				if(!host.endsWith("/")){
+					host += "/";
+				}
+				this.serverHost=host+"v2";
+			}else{
+				// host is hostname, assume default self-hosting API endpoint path
+				this.serverHost=host+"/timetagger/api/v2";
+			}
 			this.serverToken=token;
 			this.getTitle=getTitle;
 		}

--- a/src/timetagger.ts
+++ b/src/timetagger.ts
@@ -10,14 +10,17 @@ export namespace timetagger {
 		getTitle : Function
 
 		constructor(host: string ,token : string, getTitle : Function){
+			if(host.endsWith("/")){
+				host = host.slice(0,-1);
+			}
 			if(host.indexOf("/api")>0){
-				// host is API endpoint
-				if(!host.endsWith("/")){
-					host += "/";
-				}
-				this.serverHost=host+"v2";
+				// full URL, assume that user knows what to do
+				this.serverHost=host;
+			} else if(host="https://timetagger.app"){
+				// Using timetagger.app service
+				this.serverHost=host+"/api/v2";
 			}else{
-				// host is hostname, assume default self-hosting API endpoint path
+				// assume default self-hosting API endpoint
 				this.serverHost=host+"/timetagger/api/v2";
 			}
 			this.serverToken=token;


### PR DESCRIPTION
Hi!

TimeTagger dev here :)  I just learned about this plugin. Nice to see timetagger finding its way to other tools!

I got a question from a user though, which lead me to this PR.

The way that the API endpoint is calculated assumes the default self-hosting API path. E.g. for timetagger.app, the API path is `https://timetagger.app/api/`, but this cannot be used right now. This PR allows specifying the full API path to work around this limitation.
